### PR TITLE
breaking: support append in flags

### DIFF
--- a/changelog/unreleased/support-append-in-command-flag.md
+++ b/changelog/unreleased/support-append-in-command-flag.md
@@ -1,0 +1,8 @@
+Enhancement: Support append() in cli.Command.Flags (Breaking Change)
+
+Some oCIS extensions use multiple `[]cli.Flag` slices in `cli.Command{Flags: xxx}`
+by appending them in place. The support for this to work is added in this PR. In order to 
+return multiple flagset names, the type of ParsedCommand.Flags is changed
+from string to []string. This breaks existing templates and the user needs to update them.
+
+https://github.com/owncloud/flaex/pull/9

--- a/templates/CONFIGURATION.tmpl
+++ b/templates/CONFIGURATION.tmpl
@@ -7,13 +7,15 @@ geekdocEditPath: edit/master/docs
 geekdocFilePath: configuration.md
 ---
 {{- define "options"}}
-{{ $fnName := (last . ).Flags -}}
-{{ range $opt := first . }}{{ with list $fnName $opt -}}
+{{ $fnNames := (last . ).Flags -}}
+{{ range $opt := first . }}
+{{ range $fnName := $fnNames }}{{ with list $fnName $opt -}}
 {{ $o := last . -}}
 {{ if eq $o.FnName $fnName -}}
---{{ $o.Name }} | ${{ index $o.Env 0 }}  
+-{{ $o.Name }} | {{ range $i, $e := $o.Env }} {{ if $i }}, {{ end }}${{ $e }}{{ end }}
 : {{ $o.Usage }}. {{- if $o.Default }} Default: `{{ $o.Default }}`.{{ end }}
 
+{{ end -}}
 {{ end -}}
 {{ end -}}
 {{ end -}}


### PR DESCRIPTION
```go
// Server is the entrypoint for the server command.
func Server(cfg *config.Config) *cli.Command {
	return &cli.Command{
		Name:  "server",
		Usage: "Start integrated server",
		Flags: append(flagset.ServerWithConfig(cfg), flagset.RootWithConfig(cfg)...),
...
```
does currently not produce proper documentation since flaex does not know how to deal with `append()`. This is eg. used here: https://github.com/owncloud/ocis/blob/master/web/pkg/command/server.go#L25


This PR adds this functionality for append in flags but therefore the type signature of ParsedCommand changes:

```
 // ParsedCommand represents a single Configuration option
 type ParsedCommand struct {
        Name   string
        Usage  string
-       Flags  string
+       Flags  []string
        Type   string
        FnName string
 }
```

This is a breaking change and needs adaption in the used template, eg for Web in oCIS (https://github.com/owncloud/ocis/blob/master/web/templates/CONFIGURATION.tmpl) you need now following define for option:
```
{{- define "options"}}
{{ $fnNames := (last . ).Flags -}}
{{ range $opt := first . }}
{{ range $fnName := $fnNames }}{{ with list $fnName $opt -}}
{{ $o := last . -}}
{{ if eq $o.FnName $fnName -}}
-{{ $o.Name }} | {{ range $i, $e := $o.Env }} {{ if $i }}, {{ end }}${{ $e }}{{ end }}
: {{ $o.Usage }}. {{- if $o.Default }} Default: `{{ $o.Default }}`.{{ end }}

{{ end -}}
{{ end -}}
{{ end -}}
{{ end -}}
{{ end }}
```

The breaking change should be considered in the version of the next flaex release but should not cause other issues, since flaex is only used in a versioned fashion in all non archived ownCloud-Github-Repos (https://github.com/search?p=1&q=org%3Aowncloud+flaex&type=Code).
Therefore one can update flaex and the templates in one PR in the respective repositories.