### PR TITLE
strip OverrideDefault* from flagset values

### DIFF
--- a/pkg/parsers/flagset.go
+++ b/pkg/parsers/flagset.go
@@ -116,6 +116,8 @@ func getValue(kvExpr ast.Expr) (value string) {
 					if len(fun.Args) == 2 {
 						if val, ok := fun.Args[1].(*ast.BasicLit); ok {
 							return val.Value
+						} else if val, ok := fun.Args[1].(*ast.Ident); ok {
+							return val.Name
 						}
 					}
 				}
@@ -125,3 +127,5 @@ func getValue(kvExpr ast.Expr) (value string) {
 	}
 	return value
 }
+
+// TODO: GLAUTH_BACKEND_USE_GRAPHAPI


### PR DESCRIPTION
Remove the confusing `OverrideDefault*` from flagset values
![image](https://user-images.githubusercontent.com/34452982/124093221-f0174980-da57-11eb-8a6c-30735068c71d.png)

It will then look like this:
![image](https://user-images.githubusercontent.com/34452982/124096710-20acb280-da5b-11eb-9f9d-c8bd19348070.png)

Also numeric values are now present in the documentation and it also displays mathematic operations:

![image](https://user-images.githubusercontent.com/34452982/124111226-59538880-da69-11eb-96f5-10c81230e047.png)


Some corner cases are still left:
![image](https://user-images.githubusercontent.com/34452982/124093856-8481ac00-da58-11eb-9d75-9c66a9b3a36a.png)
